### PR TITLE
Correcting typo in geometry.py

### DIFF
--- a/calfem/geometry.py
+++ b/calfem/geometry.py
@@ -39,7 +39,7 @@ class Geometry:
 
     def removeCurve(self, ID):
         '''Removes the curve with this ID'''
-        self.curve.pop(ID)
+        self.curves.pop(ID)
 
     def removeSurface(self, ID):
         '''Removes the surface with this ID'''


### PR DESCRIPTION
In the function "removeCurve", the line 42 should be self.curves.pop(ID) instead of self.curve.pop(ID)