### PR TITLE
Fix error in ex1 docs and update requirements to pass rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
-visvis
+lsvisvis
 PyQt5
 pyvtk
 calfem-python
+ipython
 sphinx==4.0.2
 nbsphinx==0.8.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ visvis
 PyQt5
 pyvtk
 calfem-python
+ipython_genutils==0.2.0
 sphinx==4.1.0
 nbsphinx==0.8.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,6 @@ visvis
 PyQt5
 pyvtk
 calfem-python
-ipython_genutils==0.2.0
-sphinx==4.1.0
+ipython_genutils==0.1.0
+sphinx==4.0.2
 nbsphinx==0.8.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-lsvisvis
+visvis
 PyQt5
 pyvtk
 calfem-python

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,5 @@ visvis
 PyQt5
 pyvtk
 calfem-python
-ipython
-sphinx==4.0.2
+sphinx==4.1.0
 nbsphinx==0.8.6

--- a/docs/source/exs1.rst
+++ b/docs/source/exs1.rst
@@ -87,6 +87,11 @@ from the global displacements `a` using the function extract.
 The spring element forces at each element are evaluated using the function spring1s. 
 
  .. literalinclude:: ../../examples/exs1.py
+    :lines: 63-66
+
+
+Print those elements as N1, N2, and N3 (N for normal forces).
+ .. literalinclude:: ../../examples/exs1.py
     :lines: 68-70
 
 Output: ::

--- a/docs/source/exs1.rst
+++ b/docs/source/exs1.rst
@@ -67,7 +67,7 @@ given in bc.
  .. literalinclude:: ../../examples/exs1.py
     :lines: 49-56
 
-output: ::
+Output: ::
 
    Displacements a:
    [[0.        ]
@@ -84,6 +84,7 @@ from the global displacements `a` using the function extract.
  .. literalinclude:: ../../examples/exs1.py
     :lines: 59-61  
 
+
 The spring element forces at each element are evaluated using the function spring1s. 
 
  .. literalinclude:: ../../examples/exs1.py
@@ -91,6 +92,7 @@ The spring element forces at each element are evaluated using the function sprin
 
 
 Print those elements as N1, N2, and N3 (N for normal forces).
+
  .. literalinclude:: ../../examples/exs1.py
     :lines: 68-70
 

--- a/examples/exs1.py
+++ b/examples/exs1.py
@@ -18,14 +18,14 @@ import calfem.core as cfc
 
 # Topology matrix Edof 
 Edof = np.array([
-    [1,2],      # element 1 between node 1 and 2
-    [2,3],      # element 2 between node 2 and 3
-    [2,3]       # element 3 between node 2 and 3
+    [1, 2],      # element 1 between node 1 and 2
+    [2, 3],      # element 2 between node 2 and 3
+    [2, 3]       # element 3 between node 2 and 3
 ])
 
 # Stiffness matrix K and load vector f 
-K = np.zeros((3,3))
-f = np.zeros((3,1))
+K = np.zeros((3, 3))
+f = np.zeros((3, 1))
 
 # Element stiffness matrices  
 k = 1500.
@@ -35,15 +35,15 @@ Ke1 = cfc.spring1e(ep1)
 Ke2 = cfc.spring1e(ep2)
 
 # Assemble Ke into K 
-cfc.assem(Edof[0,:], K, Ke2)
-cfc.assem(Edof[1,:], K, Ke1)
-cfc.assem(Edof[2,:], K, Ke2)
+cfc.assem(Edof[0, :], K, Ke2)
+cfc.assem(Edof[1, :], K, Ke1)
+cfc.assem(Edof[2, :], K, Ke2)
 
 print("Stiffness matrix K:")
 print(K)
 
 # f[1] corresponds to edof 2
-f[1]=100                    
+f[1] = 100                    
     
 # Solve the system of equations 
 bc = np.array([1,3])
@@ -60,9 +60,9 @@ ed1 = cfc.extractEldisp(Edof[0,:],a)
 ed2 = cfc.extractEldisp(Edof[1,:],a)
 ed3 = cfc.extractEldisp(Edof[2,:],a)
 
-es1 = cfc.spring1s(ep2,ed1)
-es2 = cfc.spring1s(ep1,ed2)
-es3 = cfc.spring1s(ep2,ed3)
+es1 = cfc.spring1s(ep2, ed1)
+es2 = cfc.spring1s(ep1, ed2)
+es3 = cfc.spring1s(ep2, ed3)
 
 print("Element forces N:")
 print("N1 = "+str(es1))


### PR DESCRIPTION
This PR does:
- fix missing steps in ex1 (calling `cfc.spring1s` bofre print it
- fix falling on the read the docs by adding `ipython_genutils` in doc's requirements.txt