### PR TITLE
bug fix plante: fix orientation of returned fe

### DIFF
--- a/calfem/core.py
+++ b/calfem/core.py
@@ -2662,7 +2662,7 @@ def plante(ex, ey, ep, D, eq=None):
         if eq is None:
             return Ke
         else:
-            return Ke, fe.T
+            return Ke, fe
 
     #--------- plane strain --------------------------------------
 
@@ -2686,7 +2686,7 @@ def plante(ex, ey, ep, D, eq=None):
         if eq == None:
             return Ke
         else:
-            return Ke, fe.T
+            return Ke, fe
 
     else:
         info("Error ! Check first argument, ptype=1 or 2 allowed")


### PR DESCRIPTION
`plante` returned a row instead of a column vector for `fe`.

This caused a dimension mismatch error when assembling the force vector by `assem`, because `assem` would create a matrix when adding the row vector to the global column vector.