### PR TITLE
Proper checking for `np.array == None`

### DIFF
--- a/calfem/core.py
+++ b/calfem/core.py
@@ -636,7 +636,7 @@ def beam2t(ex, ey, ep, eq=None):
     Ke = G.T*Kle*G
     fe = G.T*fle
 
-    if eq == None:
+    if eq is None:
         return Ke
     else:
         return Ke, fe
@@ -1301,7 +1301,7 @@ def beam3e(ex, ey, ez, eo, ep, eq=None):
     Ke = G.T*Kle*G
     fe = G.T*fle
 
-    if eq == None:
+    if eq is None:
         return Ke
     else:
         return Ke, fe
@@ -1468,7 +1468,7 @@ def beam3s(ex, ey, ez, eo, ep, ed, eq=None, n=None):
             [0, 0, 0,    0,    0, 0, 0,    0,    0, 0, x, 1]
         ])*m+np.array([-qx*x**2/(2*EA), qy*x**4/(24*EIz), qz*x**4/(24*EIy), -qw*x**2/(2*GKv)]).reshape(4, 1)).T
 
-    if n == None:
+    if n is None:
         return es
     else:
         return es, edi, eci
@@ -1498,7 +1498,7 @@ def flw2te(ex, ey, ep, D, eq=None):
     
     """
     t = ep[0]
-    if eq == None:
+    if eq is None:
         eq = 0.
 
     exm = np.asmatrix(ex)
@@ -1608,7 +1608,7 @@ def flw2qe(ex, ey, ep, D, eq=None):
     K = np.zeros((5, 5))
     f = np.zeros((5, 1))
 
-    if eq == None:
+    if eq is None:
         k1 = flw2te([ex[0], ex[1], xc], [ey[0], ey[1], yc], ep, D)
         K = assem(np.array([1, 2, 5]), K, k1)
         k1 = flw2te([ex[1], ex[2], xc], [ey[1], ey[2], yc], ep, D)
@@ -1631,7 +1631,7 @@ def flw2qe(ex, ey, ep, D, eq=None):
     Ke = Ke1
     fe = fe1
 
-    if eq == None:
+    if eq is None:
         return Ke
     else:
         return Ke, fe
@@ -1672,7 +1672,7 @@ def flw2qs(ex, ey, ep, D, ed, eq=None):
     xm = sum(ex)/4
     ym = sum(ey)/4
 
-    if eq == None:
+    if eq is None:
         q = 0
     else:
         q = eq
@@ -1692,7 +1692,7 @@ def flw2qs(ex, ey, ep, D, ed, eq=None):
     ex4 = np.array([ex[3], ex[0], xm])
     ey4 = np.array([ey[3], ey[0], ym])
 
-    if eq == None:
+    if eq is None:
         k1 = flw2te(ex1, ey1, ep, D)
         K = assem(En[0], K, k1)
         k1 = flw2te(ex2, ey2, ep, D)
@@ -1758,7 +1758,7 @@ def flw2i4e(ex, ey, ep, D, eq=None):
     ir = ep[1]
     ngp = ir*ir
 
-    if eq == None:
+    if eq is None:
         q = 0
     else:
         q = eq
@@ -1847,7 +1847,7 @@ def flw2i4e(ex, ey, ep, D, eq=None):
         Ke1 = Ke1+B.T*D*B*detJ*wp[i].item()
         fe1 = fe1+N[i, :].T*detJ*wp[i]
 
-    if eq == None:
+    if eq is None:
         return Ke1*t
     else:
         return Ke1*t, fe1*t*eq
@@ -2007,7 +2007,7 @@ def flw2i8e(ex, ey, ep, D, eq=None):
     ir = ep[1]
     ngp = ir*ir
 
-    if eq == None:
+    if eq is None:
         q = 0
     else:
         q = eq
@@ -2311,7 +2311,7 @@ def flw3i8e(ex, ey, ez, ep, D, eq=None):
     ir = ep[0]
     ngp = ir*ir*ir
 
-    if eq == None:
+    if eq is None:
         q = 0
     else:
         q = eq
@@ -2683,14 +2683,14 @@ def plante(ex, ey, ep, D, eq=None):
         Ke = B.T*Dm*B*A*t
         fe = A/3*np.mat([bx, by, bx, by, bx, by]).T*t
 
-        if eq == None:
+        if eq is None:
             return Ke
         else:
             return Ke, fe.T
 
     else:
         info("Error ! Check first argument, ptype=1 or 2 allowed")
-        if eq == None:
+        if eq is None:
             return None
         else:
             return None, None
@@ -3069,7 +3069,7 @@ def planqe(ex, ey, ep, D, eq=None):
     K, f = assem(np.array([7, 8, 1, 2, 9, 10]), K, ke1, f, fe1)
     Ke, fe = statcon(K, f, np.array([[9], [10]]))
 
-    if eq == None:
+    if eq is None:
         return Ke
     else:
         return Ke, fe
@@ -3189,7 +3189,7 @@ def plani4e(ex, ey, ep, D, eq=None):
     t = ep[1]
     ir = ep[2]
     ngp = ir*ir
-    if eq == None:
+    if eq is None:
         q = np.zeros((2, 1))
     else:
         q = np.reshape(eq, (2, 1))
@@ -3383,7 +3383,7 @@ def soli8e(ex, ey, ez, ep, D, eqp=None):
     ir = ep[0]
     ngp = ir*ir*ir
 
-    if eqp == None:
+    if eqp is None:
         eq = np.zeros((3, 1))
     else:
         eq = eqp


### PR DESCRIPTION
The current codebase checks `np.array == None` in a lot of places, for instance for body forces in core.planqe. This causes an exception in numpy, crashing the program. 

This change instead uses the `np.array is None` pattern to do such checks, as it instead compares the type of the array to None, rather than the value (which == does).